### PR TITLE
Update appendix_built_in_types.rst

### DIFF
--- a/docs/source/8_appendix/appendix_built_in_types.rst
+++ b/docs/source/8_appendix/appendix_built_in_types.rst
@@ -242,7 +242,7 @@ Supported operators for the Int and Long type
 |     |                            |                                                      |  
 |     |                            |   operand.                                           |
 +-----+----------------------------+------------------------------------------------------+
-|  -  |   Int, Double, Float, Long |   Subtracts the operand value from the value.        |
+| \-  |   Int, Double, Float, Long |   Subtracts the operand value from the value.        |
 +-----+----------------------------+------------------------------------------------------+
 | \*  |   Int, Double, Float, Long |   Multiplies the value with the operand value.       |
 +-----+----------------------------+------------------------------------------------------+
@@ -369,7 +369,7 @@ Supported operators for the Float and Double type
 |     |                            |                                                      |  
 |     |                            |   operand.                                           |
 +-----+----------------------------+------------------------------------------------------+
-|  -  |   Int, Double, Float, Long |   Subtracts the operand value from the value.        |
+| \-  |   Int, Double, Float, Long |   Subtracts the operand value from the value.        |
 +-----+----------------------------+------------------------------------------------------+
 | \*  |   Int, Double, Float, Long |   Multiplies the value with the operand value.       |
 +-----+----------------------------+------------------------------------------------------+


### PR DESCRIPTION
escaped "-" character in operator lists.